### PR TITLE
Add continuous deployment to proxy server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,5 +167,5 @@ jobs:
           export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
           echo $PROXY_SERVER_GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
-          gcloud beta container clusters get-credentials dev-73f526d-ropsten-01 --region asia-southeast1 --project omisego-development
+          gcloud beta container clusters get-credentials dev-6f757ea-ropsten-01 --region asia-southeast1 --project omisego-development
           kubectl set image deployment/mobile-wallet-proxy mobile-wallet-proxy=$PROXY_SERVER_DOCKER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ workflows:
       - proxy-server-publish:
           requires:
             - proxy-server-test
+      - proxy-server-deploy:
+          requires:
+            - proxy-server-publish
           filters:
             branches:
               only: master
@@ -143,15 +146,25 @@ jobs:
       - image: google/cloud-sdk
     steps:
       - checkout
-      - run: cd proxy-server
       - setup_remote_docker
       - run: |
           export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
           export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
           echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
+          cd proxy-server
           docker build -t $PROXY_SERVER_DOCKER_IMAGE_NAME .
           docker tag $PROXY_SERVER_DOCKER_IMAGE_NAME $PROXY_SERVER_DOCKER_TAG
           docker push $PROXY_SERVER_DOCKER_TAG
+
+  proxy-server-deploy:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - run: |
+          export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+          export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
+          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+          gcloud auth configure-docker
           gcloud beta container clusters get-credentials dev-73f526d-ropsten-01 --region asia-southeast1 --project omisego-development
           kubectl set image deployment/mobile-wallet-proxy mobile-wallet-proxy=$PROXY_SERVER_DOCKER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,8 +146,12 @@ jobs:
       - run: cd proxy-server
       - setup_remote_docker
       - run: |
+          export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+          export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
           echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
-          docker build -t $DOCKER_IMAGE_NAME .
-          docker tag $DOCKER_IMAGE_NAME $DOCKER_REPO_URL
-          docker push $DOCKER_REPO_URL
+          docker build -t $PROXY_SERVER_DOCKER_IMAGE_NAME .
+          docker tag $PROXY_SERVER_DOCKER_IMAGE_NAME $PROXY_SERVER_DOCKER_TAG
+          docker push $PROXY_SERVER_DOCKER_TAG
+          gcloud beta container clusters get-credentials dev-73f526d-ropsten-01 --region asia-southeast1 --project omisego-development
+          kubectl set image deployment/mobile-wallet-proxy mobile-wallet-proxy=$PROXY_SERVER_DOCKER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,8 @@ jobs:
     docker:
       - image: google/cloud-sdk
     steps:
-      - checkout
+      - attach_workspace:
+          at: .
       - setup_remote_docker
       - run: |
           export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       - run: |
           export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
           export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
-          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+          echo $PROXY_SERVER_GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
           cd proxy-server
           docker build -t $PROXY_SERVER_DOCKER_IMAGE_NAME .
@@ -165,7 +165,7 @@ jobs:
       - run: |
           export SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
           export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
-          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+          echo $PROXY_SERVER_GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
           gcloud beta container clusters get-credentials dev-73f526d-ropsten-01 --region asia-southeast1 --project omisego-development
           kubectl set image deployment/mobile-wallet-proxy mobile-wallet-proxy=$PROXY_SERVER_DOCKER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,5 +167,5 @@ jobs:
           export PROXY_SERVER_DOCKER_TAG=$(echo $PROXY_SERVER_DOCKER_REPO_URL:$SHORT_GIT_HASH)
           echo $PROXY_SERVER_GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud auth configure-docker
-          gcloud beta container clusters get-credentials dev-6f757ea-ropsten-01 --region asia-southeast1 --project omisego-development
+          gcloud beta container clusters get-credentials $PROXY_SERVER_GCP_CLUSTER_DEVELOPMENT --region $PROXY_SERVER_GCP_REGION --project $PROXY_SERVER_GCP_PROJECT
           kubectl set image deployment/mobile-wallet-proxy mobile-wallet-proxy=$PROXY_SERVER_DOCKER_TAG

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:10-alpine
-
-COPY . /app
+# Install project dependencies from an image that has all the build toolings available
+FROM circleci/node:10 as builders
 WORKDIR /app
 
-EXPOSE 3000
-
+COPY package.json package-lock.json /app
 RUN npm install
 
-RUN npm run build
+# Now copy the artifacts over and build the final image from a clean node alpine
+FROM node:10-alpine
+WORKDIR /app
 
+COPY . /app
+COPY --from=builder /app/node_modules /app/node_modules
+
+EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -18,7 +18,7 @@ FROM node:10-alpine as app
 WORKDIR /app
 
 COPY . /app
-COPY --from=builder ./node_modules ./node_modules
+COPY --from=builder /app/node_modules /app/node_modules
 
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -1,8 +1,7 @@
 # Install project dependencies from an image that has all the build toolings available
-FROM circleci/node:10 as builders
-WORKDIR /app
+FROM circleci/node:10 as builder
 
-COPY package.json package-lock.json /app/
+COPY package.json package-lock.json ./
 RUN npm install
 
 # Now copy the artifacts over and build the final image from a clean node alpine
@@ -10,7 +9,7 @@ FROM node:10-alpine
 WORKDIR /app
 
 COPY . /app
-COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder ./node_modules /app/node_modules
 
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -1,4 +1,7 @@
+#
 # Install project dependencies from an image that has all the build toolings available
+#
+
 FROM node:10-alpine as builder
 WORKDIR /app
 
@@ -6,12 +9,20 @@ COPY . /app
 
 RUN apk add --no-cache python
 RUN npm install
+RUN pwd
+RUN ls
 
+#
 # Now copy the artifacts over and build the final image from a clean node alpine
+#
+
 FROM node:10-alpine as app
 
+RUN pwd
+RUN ls
+
 COPY . /app
-COPY --from=builder node_modules ./node_modules
+COPY --from=builder ./node_modules ./node_modules
 
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -2,7 +2,7 @@
 FROM circleci/node:10 as builders
 WORKDIR /app
 
-COPY package.json package-lock.json /app
+COPY package.json package-lock.json /app/
 RUN npm install
 
 # Now copy the artifacts over and build the final image from a clean node alpine

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -1,15 +1,17 @@
 # Install project dependencies from an image that has all the build toolings available
-FROM circleci/node:10 as builder
-
-COPY package.json package-lock.json ./
-RUN npm install
-
-# Now copy the artifacts over and build the final image from a clean node alpine
-FROM node:10-alpine
+FROM node:10-alpine as builder
 WORKDIR /app
 
 COPY . /app
-COPY --from=builder ./node_modules /app/node_modules
+
+RUN apk add --no-cache python
+RUN npm install
+
+# Now copy the artifacts over and build the final image from a clean node alpine
+FROM node:10-alpine as app
+
+COPY . /app
+COPY --from=builder node_modules ./node_modules
 
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/proxy-server/Dockerfile
+++ b/proxy-server/Dockerfile
@@ -9,17 +9,13 @@ COPY . /app
 
 RUN apk add --no-cache python
 RUN npm install
-RUN pwd
-RUN ls
 
 #
 # Now copy the artifacts over and build the final image from a clean node alpine
 #
 
 FROM node:10-alpine as app
-
-RUN pwd
-RUN ls
+WORKDIR /app
 
 COPY . /app
 COPY --from=builder ./node_modules ./node_modules


### PR DESCRIPTION
Build a docker image inside `./proxy-server`, then publish to the private GCP container registry.

Mostly copied from https://github.com/omisego/blockexplorer/blob/master/.circleci/config.yml#L36-L45