### PR TITLE
Fix proxy server's missing express-rate-limit and remove sensitive logging

### DIFF
--- a/proxy-server/README.md
+++ b/proxy-server/README.md
@@ -15,3 +15,16 @@ Run the following command to start the proxy server:
 ```shell
 node index.js
 ```
+
+## Configurations
+
+Configure these environment variables to modify the behaviour of the proxy server.
+
+- `PORT`: The port that the proxy server listens to incoming requests. Defaults to `3000`.
+- `ETHEREUM_RPC_URL`: The Ethereum client to forward the request to. Defaults to `http://localhost:8545`.
+- `LOG_LEVEL`: The log level. Accepts "debug", "info", "warn", "error" and "silent". Defaults to `info`.
+- `DD_HOSTNAME`: The DataDog's hostname. Defaults to `localhost`.
+- `DD_PORT`: The DataDog's post. Defaults to `8125`.
+- `RATE_LIMIT_WINDOW_MS`: The rate limit window period in milliseconds. Defaults to `3600000` (60 minutes).
+- `RATE_LIMIT`: The number of requests allowed from a single IP per window period. Defaults to `600` (600 requests per IP per 60 minutes).
+- `SENTRY_DSN`: The Sentry DSN to report errors to. Defaults to empty string (error not reported).

--- a/proxy-server/index.js
+++ b/proxy-server/index.js
@@ -8,7 +8,6 @@ const Sentry = require('./utils/error-reporter')
 
 console.log('Initializing mobile wallet proxy-server app...')
 console.log('PORT:', CONFIG.PORT)
-console.log('ETHEREUM_RPC_URL:', CONFIG.ETHEREUM_RPC_URL)
 console.log('LOG_LEVEL:', CONFIG.LOG_LEVEL)
 
 const app = express()

--- a/proxy-server/package-lock.json
+++ b/proxy-server/package-lock.json
@@ -2218,6 +2218,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.1.tgz",
+      "integrity": "sha512-puA1zcCx/quwWUOU6pT6daCt6t7SweD9wKChKhb+KSgFMKRwS81C224hiSAUANw/gnSHiwEhgozM/2ezEBZPeA=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/proxy-server/package.json
+++ b/proxy-server/package.json
@@ -23,6 +23,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.1.1",
     "hot-shots": "^6.8.5",
     "http-proxy-middleware": "^0.20.0",
     "winston": "^3.2.1"


### PR DESCRIPTION
Closes #119
Fixes https://sentry.io/organizations/omisego/issues/1525108784

## Changes
- Install `express-rate-limit` node dependency
- Removed `ETHEREUM_RPC_URL` logging on start that could expose infura credentials
- Added env var listing to readme