### PR TITLE
Fix can't request to infura node properly

### DIFF
--- a/proxy-server/handlers/ethereum-rpc-proxy.js
+++ b/proxy-server/handlers/ethereum-rpc-proxy.js
@@ -66,6 +66,9 @@ function ethereumRpcProxy() {
     changeOrigin: true, // To support name-based virtual hosts
     xfwd: true, // Let the host sees whom the request is being forwarded for
     ws: false, // No plans to interact with Ethereum client via websockets
+    ignorePath: true, // Ignore the request path as we always want to request to https://<NETWORK>.infura.io/v3/<INFURA_API_KEY>.
+    // Otherwise, the response will be failed because the client will override target to https://<NETWORK>.infura.io/
+    // Reference: https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/common.js#L86-L97
     logLevel: CONFIG.LOG_LEVEL,
     logProvider: logProvider, // A logger customized for more info
     onProxyReq: requestReceivedHandler,


### PR DESCRIPTION
Closes #136 

This PR fixes the proxy server excludes the url path of the target when making a request to the infura.

# Test

1. Set the ethereum rpc url to infura `ETHEREUM_RPC_URL=https://ropsten.infura.io/v3/<PROJECT_ID> npm start`
2. Request to infura through the proxy server:
```
curl -X POST \
-H "Content-Type: application/json" \
--data '{"jsonrpc": "2.0", "id": 1, "method": "eth_blockNumber", "params": []}' \
"http://localhost:3000"
```
3. Response returns `blockNumber` properly
```
{"jsonrpc":"2.0","id":1,"result":"0x7233e0"}
```