### PR TITLE
Fix rate limit

### DIFF
--- a/proxy-server/handlers/ethereum-rpc-proxy.js
+++ b/proxy-server/handlers/ethereum-rpc-proxy.js
@@ -4,18 +4,24 @@ const CONFIG = require('../config')
 const errorReporter = require('../utils/error-reporter')
 const { logger, logProvider } = require('../utils/logger')
 const metrics = require('../utils/metrics')
+const IPAddress = require('../utils/ip-address')
 
 // Collect metrics on incoming requests
 function requestReceivedHandler(proxyReq, req) {
   metrics.increment('mobile_api_proxy.num_requests')
-
+  const originalIPAddress =
+    IPAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
   // Log and measure the Ethereum's JSON-RPC method if `method` is provided.
   if (req.body.method) {
     metrics.increment('mobile_api_proxy.num_requests.' + req.body.method)
-    logger.info('Proxying ETH: ' + req.ip + ' -> ' + req.body.method)
+    logger.info('Proxying ETH: ' + originalIPAddress + ' -> ' + req.body.method)
   } else {
     logger.info(
-      'Proxying HTTP: ' + req.ip + ' -> ' + req.headers.host + req.url
+      'Proxying HTTP: ' +
+        originalIPAddress +
+        ' -> ' +
+        req.headers.host +
+        req.url
     )
   }
 

--- a/proxy-server/handlers/ethereum-rpc-proxy.js
+++ b/proxy-server/handlers/ethereum-rpc-proxy.js
@@ -4,13 +4,13 @@ const CONFIG = require('../config')
 const errorReporter = require('../utils/error-reporter')
 const { logger, logProvider } = require('../utils/logger')
 const metrics = require('../utils/metrics')
-const IPAddress = require('../utils/ip-address')
+const ipAddress = require('../utils/ip-address')
 
 // Collect metrics on incoming requests
 function requestReceivedHandler(proxyReq, req) {
   metrics.increment('mobile_api_proxy.num_requests')
   const originalIPAddress =
-    IPAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
+    ipAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
   // Log and measure the Ethereum's JSON-RPC method if `method` is provided.
   if (req.body.method) {
     metrics.increment('mobile_api_proxy.num_requests.' + req.body.method)

--- a/proxy-server/index.js
+++ b/proxy-server/index.js
@@ -13,9 +13,8 @@ console.log('LOG_LEVEL:', CONFIG.LOG_LEVEL)
 const app = express()
 
 app.use(Sentry.Handlers.requestHandler())
-app.use(rateLimiter)
 app.use(bodyParser.json())
-app.use('/api', ethereumRpcProxy())
+app.use('/api', rateLimiter(), ethereumRpcProxy())
 app.use('/', (req, res) => res.send('OK'))
 app.use(Sentry.Handlers.errorHandler())
 

--- a/proxy-server/test/utils/rateLimiter.test.js
+++ b/proxy-server/test/utils/rateLimiter.test.js
@@ -19,7 +19,7 @@ describe('rateLimiter with backend available', function() {
     app && app.close()
   })
 
-  it('should returns rate limit error when number of requests is exceeded max', function(done) {
+  it('should returns error when number of requests exceeded the limit', function(done) {
     http.get('http://localhost:3001/api', res => {
       res.on('data', chunk => {
         const responseBody = chunk.toString()

--- a/proxy-server/test/utils/rateLimiter.test.js
+++ b/proxy-server/test/utils/rateLimiter.test.js
@@ -1,0 +1,38 @@
+const http = require('http')
+const express = require('express')
+const rateLimiter = require('../../utils/rate-limiter')
+const CONFIG = require('../../config')
+
+let app
+
+describe('rateLimiter with backend available', function() {
+  beforeAll(() => {
+    // Mock rate limit for testing purpose
+    CONFIG.RATE_LIMIT = 1
+
+    const backendApp = express()
+    backendApp.get('/api', rateLimiter(), (req, res) => res.send('OK'))
+    app = backendApp.listen(3001)
+  })
+
+  afterAll(() => {
+    app && app.close()
+  })
+
+  it('should returns rate limit error when number of requests is exceeded max', function(done) {
+    http.get('http://localhost:3001/api', res => {
+      res.on('data', chunk => {
+        const responseBody = chunk.toString()
+        expect(responseBody).toBe('OK')
+        done()
+      })
+    })
+    http.get('http://localhost:3001/api', res => {
+      res.on('data', chunk => {
+        const responseBody = chunk.toString()
+        expect(responseBody).toBe('Too many requests, please try again later.')
+        done()
+      })
+    })
+  })
+})

--- a/proxy-server/utils/ip-address.js
+++ b/proxy-server/utils/ip-address.js
@@ -1,5 +1,8 @@
 const getOriginalRequestIPFromCloudFlare = req => {
-  return req.headers['CF-Connecting-IP'] || req.headers['X-Forwarded-For']
+  return (
+    req.headers['CF-Connecting-IP'] ||
+    req.headers['X-Forwarded-For'].split(',')[0]
+  )
 }
 
 module.exports = {

--- a/proxy-server/utils/ip-address.js
+++ b/proxy-server/utils/ip-address.js
@@ -1,5 +1,5 @@
 const getOriginalRequestIPFromCloudFlare = req => {
-  return req.headers['CF-Connecting-IP']
+  return req.headers['CF-Connecting-IP'] || req.headers['X-Forwarded-For']
 }
 
 module.exports = {

--- a/proxy-server/utils/ip-address.js
+++ b/proxy-server/utils/ip-address.js
@@ -1,7 +1,8 @@
 const getOriginalRequestIPFromCloudFlare = req => {
   return (
     req.headers['CF-Connecting-IP'] ||
-    req.headers['X-Forwarded-For'].split(',')[0]
+    (req.headers['X-Forwarded-For'] &&
+      req.headers['X-Forwarded-For'].split(',')[0])
   )
 }
 

--- a/proxy-server/utils/ip-address.js
+++ b/proxy-server/utils/ip-address.js
@@ -1,3 +1,7 @@
-export const getOriginalRequestIPFromCloudFlare = req => {
+const getOriginalRequestIPFromCloudFlare = req => {
   return req.headers['CF-Connecting-IP']
+}
+
+module.exports = {
+  getOriginalRequestIPFromCloudFlare
 }

--- a/proxy-server/utils/ip-address.js
+++ b/proxy-server/utils/ip-address.js
@@ -1,0 +1,3 @@
+export const getOriginalRequestIPFromCloudFlare = req => {
+  return req.headers['CF-Connecting-IP']
+}

--- a/proxy-server/utils/rate-limiter.js
+++ b/proxy-server/utils/rate-limiter.js
@@ -2,7 +2,7 @@ const rateLimit = require('express-rate-limit')
 const ipAddress = require('./ip-address')
 const CONFIG = require('../config')
 
-const keyGenerator = req => {
+const uniqueRequesterIdentifier = req => {
   return ipAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
 }
 
@@ -10,7 +10,7 @@ const rateLimiter = () =>
   rateLimit({
     windowMs: CONFIG.RATE_LIMIT_WINDOW_MS,
     max: CONFIG.RATE_LIMIT,
-    keyGenerator
+    keyGenerator: uniqueRequesterIdentifier
   })
 
 module.exports = rateLimiter

--- a/proxy-server/utils/rate-limiter.js
+++ b/proxy-server/utils/rate-limiter.js
@@ -1,8 +1,9 @@
 const rateLimit = require('express-rate-limit')
+const IPAddress = require('./ip-address')
 const CONFIG = require('../config')
 
 const keyGenerator = req => {
-  return req.ip
+  return IPAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
 }
 
 const rateLimiter = () =>

--- a/proxy-server/utils/rate-limiter.js
+++ b/proxy-server/utils/rate-limiter.js
@@ -1,9 +1,15 @@
 const rateLimit = require('express-rate-limit')
 const CONFIG = require('../config')
 
-const rateLimiter = rateLimit({
-  windowMs: CONFIG.RATE_LIMIT_WINDOW_MS,
-  max: CONFIG.RATE_LIMIT
-})
+const keyGenerator = req => {
+  return req.ip
+}
+
+const rateLimiter = () =>
+  rateLimit({
+    windowMs: CONFIG.RATE_LIMIT_WINDOW_MS,
+    max: CONFIG.RATE_LIMIT,
+    keyGenerator
+  })
 
 module.exports = rateLimiter

--- a/proxy-server/utils/rate-limiter.js
+++ b/proxy-server/utils/rate-limiter.js
@@ -1,9 +1,9 @@
 const rateLimit = require('express-rate-limit')
-const IPAddress = require('./ip-address')
+const ipAddress = require('./ip-address')
 const CONFIG = require('../config')
 
 const keyGenerator = req => {
-  return IPAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
+  return ipAddress.getOriginalRequestIPFromCloudFlare(req) || req.ip
 }
 
 const rateLimiter = () =>


### PR DESCRIPTION
Closes #142 

This PR changes 2 things:
1. Exclude the health check endpoint from rate-limit count.
2. Read the original IP address from Cloudflare's headers.