### PR TITLE
Secure private key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/
 local.properties
 *.iml
 *.apk
+*.aab
 output.json
 
 # node.js
@@ -74,7 +75,7 @@ google-services.json
 
 # Credentials
 keystore.properties
-release.keystore
+*.keystore
 GoogleService-Info.plist
 android/app/src/main/assets/containers
 ios/container

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,9 +83,10 @@ project.ext.react = [
 ]
 
 // Load Keystore credentials
-def keystorePropertiesFile= rootProject.file("keystore.properties")
+def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
 
 apply from: "../../node_modules/react-native/react.gradle"
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
@@ -139,8 +140,8 @@ android {
         applicationId "network.omisego.plasmawallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 22
-        versionName "0.4.11"
+        versionCode 24
+        versionName "0.4.13"
         multiDexEnabled true
         missingDimensionStrategy "react-native-camera", "general"
     }
@@ -160,7 +161,7 @@ android {
             keyPassword 'android'
         }
         release {
-            storeFile file('release.keystore')
+            storeFile file('upload-key.keystore')
             keyAlias keystoreProperties['keyAlias']
             keyPassword keystoreProperties['keyPassword']
             storePassword keystoreProperties['storePassword']

--- a/android/app/src/main/java/network/omisego/plasmawallet/MainApplication.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/MainApplication.java
@@ -7,10 +7,10 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import io.intercom.android.sdk.Intercom;
 import io.invertase.firebase.analytics.RNFirebaseAnalyticsPackage;
 import network.omisego.plasmawallet.schedule.TaskSchedulerPackage;
-import com.robinpowered.react.Intercom.IntercomPackage;
-import io.intercom.android.sdk.Intercom;
+import network.omisego.plasmawallet.security.SecureEncryptPackage;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
@@ -28,6 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       packages.add(new RNFirebaseAnalyticsPackage());
       packages.add(new TaskSchedulerPackage());
+      packages.add(new SecureEncryptPackage());
       return packages;
     }
 

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
@@ -1,15 +1,9 @@
 package network.omisego.plasmawallet.security;
 
-/*
- * OmiseGO
- *
- * Created by Phuchit Sirimongkolsathien on 2020-04-08.
- * Copyright © 2019 OmiseGO. All rights reserved.
- */
-
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
+
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.spec.IvParameterSpec;
@@ -21,7 +15,7 @@ import java.security.spec.AlgorithmParameterSpec;
 public class SecureEncrypt {
 
     private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
-    private static final String CIPHER_TRANSFORMATION = "RSA/ECB/PKCS1Padding";
+    private static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS7Padding";
     private static final String IV_SEPARATOR = "#";
     private KeyStore keyStore;
     private String keyAlias;
@@ -29,7 +23,7 @@ public class SecureEncrypt {
 
     private Cipher cipher;
 
-    public void SecureEncrypt(String keyAlias) throws SecureEncryptException {
+    public SecureEncrypt(String keyAlias) throws SecureEncryptException {
         this.keyAlias = keyAlias;
         try {
             this.keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
@@ -53,14 +47,22 @@ public class SecureEncrypt {
             KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
             int purposes = KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             KeyGenParameterSpec spec = new KeyGenParameterSpec.Builder(keyAlias, purposes)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                    .setRandomizedEncryptionRequired(true)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
                     .build();
             keyGenerator.init(spec);
             keyGenerator.generateKey();
         } catch (Throwable cause) {
             throw new SecureEncryptException("Cannot generate key for the SecureEncrypt", cause);
+        }
+    }
+
+    public void deleteKeystore(String alias) throws SecureEncryptException {
+        try {
+            this.keyStore.deleteEntry(alias);
+            this.keyStore.store(null);
+        } catch (Throwable cause) {
+            throw new SecureEncryptException("Cannot delete keystore " + alias, cause);
         }
     }
 

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
@@ -1,0 +1,103 @@
+package network.omisego.plasmawallet.security;
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 2020-04-08.
+ * Copyright © 2019 OmiseGO. All rights reserved.
+ */
+
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.spec.AlgorithmParameterSpec;
+
+public class SecureEncrypt {
+
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String CIPHER_TRANSFORMATION = "RSA/ECB/PKCS1Padding";
+    private static final String IV_SEPARATOR = "#";
+    private KeyStore keyStore;
+    private String keyAlias;
+    private Key secretKey;
+
+    private Cipher cipher;
+
+    public void SecureEncrypt(String keyAlias) throws SecureEncryptException {
+        this.keyAlias = keyAlias;
+        try {
+            this.keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+            this.keyStore.load(null);
+            if (!hasKey(keyAlias)) {
+                generateKey();
+            }
+            this.secretKey = keyStore.getKey(keyAlias, null);
+            this.cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+        } catch (Throwable cause) {
+            throw new SecureEncryptException("Cannot initialize the SecureEncrypt", cause);
+        }
+    }
+
+    private boolean hasKey(String keyAlias) throws KeyStoreException {
+        return keyStore.containsAlias(keyAlias);
+    }
+
+    private void generateKey() throws SecureEncryptException {
+        try {
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+            int purposes = KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+            KeyGenParameterSpec spec = new KeyGenParameterSpec.Builder(keyAlias, purposes)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build();
+            keyGenerator.init(spec);
+            keyGenerator.generateKey();
+        } catch (Throwable cause) {
+            throw new SecureEncryptException("Cannot generate key for the SecureEncrypt", cause);
+        }
+    }
+
+    public String encrypt(String msg) throws SecureEncryptException {
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, this.secretKey);
+            byte[] iv = cipher.getIV();
+            byte[] encryptedMsg = cipher.doFinal(msg.getBytes());
+            String encodedIV = encode(iv);
+            String encodedEncryptedMsg = encode(encryptedMsg);
+            return encodedIV + IV_SEPARATOR + encodedEncryptedMsg;
+        } catch (Throwable cause) {
+            throw new SecureEncryptException("Cannot encrypt the msg", cause);
+        }
+    }
+
+    public String decrypt(String msg) throws SecureEncryptException {
+        try {
+            String[] parts = msg.split(IV_SEPARATOR);
+            String encodedIV = parts[0];
+            String encodedEncryptedMsg = parts[1];
+            byte[] iv = decode(encodedIV.getBytes());
+            byte[] encryptedMsg = decode(encodedEncryptedMsg.getBytes());
+            AlgorithmParameterSpec spec = new IvParameterSpec(iv);
+            cipher.init(Cipher.DECRYPT_MODE, this.secretKey, spec);
+            byte[] originalData = cipher.doFinal(encryptedMsg);
+            return new String(originalData);
+        } catch (Throwable cause) {
+            throw new SecureEncryptException("Cannot decrypt the msg", cause);
+        }
+    }
+
+    private String encode(byte[] msg) {
+        return Base64.encodeToString(msg, Base64.DEFAULT);
+    }
+
+    private byte[] decode(byte[] encodedMsg) {
+        return Base64.decode(encodedMsg, Base64.DEFAULT);
+    }
+}

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncrypt.java
@@ -15,7 +15,9 @@ import java.security.spec.AlgorithmParameterSpec;
 public class SecureEncrypt {
 
     private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
-    private static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS7Padding";
+    private static final String ALGORITHM = KeyProperties.KEY_ALGORITHM_AES;
+    private static final String BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC;
+    private static final String ENCRYPTION_PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7;
     private static final String IV_SEPARATOR = "#";
     private KeyStore keyStore;
     private String keyAlias;
@@ -32,7 +34,7 @@ public class SecureEncrypt {
                 generateKey();
             }
             this.secretKey = keyStore.getKey(keyAlias, null);
-            this.cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            this.cipher = Cipher.getInstance(ALGORITHM + "/" + BLOCK_MODE + "/" + ENCRYPTION_PADDING);
         } catch (Throwable cause) {
             throw new SecureEncryptException("Cannot initialize the SecureEncrypt", cause);
         }
@@ -44,25 +46,17 @@ public class SecureEncrypt {
 
     private void generateKey() throws SecureEncryptException {
         try {
-            KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
             int purposes = KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             KeyGenParameterSpec spec = new KeyGenParameterSpec.Builder(keyAlias, purposes)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                    .setBlockModes(BLOCK_MODE)
+                    .setEncryptionPaddings(ENCRYPTION_PADDING)
                     .build();
+
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM, ANDROID_KEY_STORE);
             keyGenerator.init(spec);
             keyGenerator.generateKey();
         } catch (Throwable cause) {
             throw new SecureEncryptException("Cannot generate key for the SecureEncrypt", cause);
-        }
-    }
-
-    public void deleteKeystore(String alias) throws SecureEncryptException {
-        try {
-            this.keyStore.deleteEntry(alias);
-            this.keyStore.store(null);
-        } catch (Throwable cause) {
-            throw new SecureEncryptException("Cannot delete keystore " + alias, cause);
         }
     }
 

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptException.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptException.java
@@ -1,13 +1,12 @@
 package network.omisego.plasmawallet.security;
 
-/*
- * OmiseGO
- *
- * Created by Phuchit Sirimongkolsathien on 2020-04-08.
- * Copyright © 2017-2018 OmiseGO. All rights reserved.
- */
 public class SecureEncryptException extends Exception {
     public SecureEncryptException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage() + getCause().getMessage();
     }
 }

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptException.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptException.java
@@ -1,0 +1,13 @@
+package network.omisego.plasmawallet.security;
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 2020-04-08.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+public class SecureEncryptException extends Exception {
+    public SecureEncryptException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptModule.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptModule.java
@@ -1,0 +1,52 @@
+package network.omisego.plasmawallet.security;
+
+import androidx.annotation.NonNull;
+import com.facebook.react.bridge.*;
+
+public class SecureEncryptModule extends ReactContextBaseJavaModule {
+    private SecureEncrypt secureEncrypt;
+
+    public SecureEncryptModule(@NonNull ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @ReactMethod
+    public void init(String keyAlias, Promise promise) {
+        try {
+            this.secureEncrypt = new SecureEncrypt(keyAlias);
+            promise.resolve(null);
+        } catch(SecureEncryptException e) {
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
+    public String encrypt(String msg, Promise promise) {
+        String result = null;
+        try {
+            result = this.secureEncrypt.encrypt(msg);
+            promise.resolve(result);
+        }catch(SecureEncryptException e) {
+            promise.reject(e);
+        }
+        return result;
+    }
+
+    @ReactMethod
+    public String decrypt(String encryptedMsg, Promise promise) {
+        String result = null;
+        try {
+            result = this.secureEncrypt.decrypt(encryptedMsg);
+            promise.resolve(result);
+        } catch(SecureEncryptException e) {
+            promise.reject(e);
+        }
+        return result;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "SecureEncrypt";
+    }
+}

--- a/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptPackage.java
+++ b/android/app/src/main/java/network/omisego/plasmawallet/security/SecureEncryptPackage.java
@@ -1,0 +1,27 @@
+package network.omisego.plasmawallet.security;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SecureEncryptPackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new SecureEncryptModule(reactContext));
+
+        return modules;
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         targetSdkVersion = "28.0.3"
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 28
         targetSdkVersion = 28
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ios-local": "ENVFILE=.env.local react-native run-ios --simulator='iPhone 7'",
     "android-local": "ENVFILE=.env.local react-native run-android",
     "build-android": "cd android && ./gradlew assembleRelease && cd .. && mkdir -p artifacts && cp android/app/build/outputs/apk/release/*.apk artifacts/",
+    "build-android-aab": "cd android && ./gradlew bundleRelease && cd .. && mkdir -p artifacts && cp android/app/build/outputs/bundle/release/*.aab artifacts/",
     "build-ios": "npm run ios-archive && npm run ios-export && mkdir -p artifacts && cp ios/build/Apps/PlasmaWallet.ipa artifacts/",
     "ios-archive": "xcodebuild archive -archivePath ios/PlasmaWallet/PlasmaWallet.xcarchive -workspace ios/PlasmaWallet.xcworkspace -scheme PlasmaWallet",
     "ios-export": "xcodebuild -exportArchive -archivePath ios/PlasmaWallet/PlasmaWallet.xcarchive -exportOptionsPlist ios/PlasmaWallet/ExportOptions.plist -exportPath ios/build",

--- a/src/common/native/index.js
+++ b/src/common/native/index.js
@@ -1,3 +1,6 @@
 import { NativeModules } from 'react-native'
+import * as SecureEncryption from './secureEncryption'
 
-export const TaskScheduler = NativeModules.TaskScheduler
+const TaskScheduler = NativeModules.TaskScheduler
+
+export { TaskScheduler, SecureEncryption }

--- a/src/common/native/secureEncryption.js
+++ b/src/common/native/secureEncryption.js
@@ -1,0 +1,17 @@
+import { NativeModules } from 'react-native'
+
+const SecureEncrypt = NativeModules.SecureEncrypt
+
+export const KEYSTORE_ALIAS = 'network.omisego.plasmawallet.ks'
+
+export const init = (alias = KEYSTORE_ALIAS) => {
+  return SecureEncrypt.init(alias)
+}
+
+export const encrypt = msg => {
+  return SecureEncrypt.encrypt(msg)
+}
+
+export const decrypt = msg => {
+  return SecureEncrypt.decrypt(msg)
+}

--- a/src/common/utils/storage.js
+++ b/src/common/utils/storage.js
@@ -5,39 +5,21 @@ import Storage from '@react-native-community/async-storage'
 
 const SECURE_STORAGE_NAME = 'OMGWallet2'
 
-// export const oldStorage = {
-//   sharedPreferencesName: 'omgwallet',
-//   keychainService: SECURE_STORAGE_NAME
-// }
-
 export const storage = {
   sharedPreferencesName: SECURE_STORAGE_NAME,
   keychainService: SECURE_STORAGE_NAME
 }
 
-// For Android only
-// export const secureExistedDataIfNeeded = async keys => {
-//   if (Platform.OS === 'ios') return
-//   for (let i = 0; i < keys.length; i++) {
-//     const insecuredData = await SecureStorage.getItem(keys[i], oldStorage)
-//     const securedData = await SecureEncryption.encrypt(insecuredData)
-//     secureSet(keys[i], securedData)
-//     await SecureStorage.deleteItem(keys[i])
-//   }
-// }
-
 export const secureSet = async (key, value) => {
   let storeValue = value
   if (Platform.OS === 'android') {
     storeValue = await SecureEncryption.encrypt(storeValue)
-    console.log('encrypted', storeValue)
   }
   return SecureStorage.setItem(key, storeValue, storage)
 }
 
 export const secureGet = async key => {
   let storedValue = await SecureStorage.getItem(key, storage)
-  console.log('undecrypted', storedValue)
   if (Platform.OS === 'android') {
     storedValue = await SecureEncryption.decrypt(storedValue)
   }

--- a/src/common/utils/storage.js
+++ b/src/common/utils/storage.js
@@ -3,7 +3,7 @@ import { SecureEncryption } from 'common/native'
 import SecureStorage from 'react-native-sensitive-info'
 import Storage from '@react-native-community/async-storage'
 
-const SECURE_STORAGE_NAME = 'OMGWallet2'
+const SECURE_STORAGE_NAME = 'network.omisego.plasmawallet.sp'
 
 export const storage = {
   sharedPreferencesName: SECURE_STORAGE_NAME,

--- a/src/common/utils/storage.js
+++ b/src/common/utils/storage.js
@@ -1,19 +1,47 @@
+import { Platform } from 'react-native'
+import { SecureEncryption } from 'common/native'
 import SecureStorage from 'react-native-sensitive-info'
 import Storage from '@react-native-community/async-storage'
 
-const SECURE_STORAGE_NAME = 'omgwallet'
+const SECURE_STORAGE_NAME = 'OMGWallet2'
 
-export const options = {
+// export const oldStorage = {
+//   sharedPreferencesName: 'omgwallet',
+//   keychainService: SECURE_STORAGE_NAME
+// }
+
+export const storage = {
   sharedPreferencesName: SECURE_STORAGE_NAME,
   keychainService: SECURE_STORAGE_NAME
 }
 
-export const secureSet = (key, value) => {
-  return SecureStorage.setItem(key, value, options)
+// For Android only
+// export const secureExistedDataIfNeeded = async keys => {
+//   if (Platform.OS === 'ios') return
+//   for (let i = 0; i < keys.length; i++) {
+//     const insecuredData = await SecureStorage.getItem(keys[i], oldStorage)
+//     const securedData = await SecureEncryption.encrypt(insecuredData)
+//     secureSet(keys[i], securedData)
+//     await SecureStorage.deleteItem(keys[i])
+//   }
+// }
+
+export const secureSet = async (key, value) => {
+  let storeValue = value
+  if (Platform.OS === 'android') {
+    storeValue = await SecureEncryption.encrypt(storeValue)
+    console.log('encrypted', storeValue)
+  }
+  return SecureStorage.setItem(key, storeValue, storage)
 }
 
-export const secureGet = key => {
-  return SecureStorage.getItem(key, options)
+export const secureGet = async key => {
+  let storedValue = await SecureStorage.getItem(key, storage)
+  console.log('undecrypted', storedValue)
+  if (Platform.OS === 'android') {
+    storedValue = await SecureEncryption.decrypt(storedValue)
+  }
+  return storedValue
 }
 
 export const set = (key, value) => {

--- a/src/components/views/initializer/index.js
+++ b/src/components/views/initializer/index.js
@@ -1,8 +1,9 @@
 import { settingActions } from 'common/actions'
 import { store } from 'common/stores'
 import { HeadlessProcessExit } from 'components/headless'
-import React, { useRef, useCallback, useEffect } from 'react'
+import React, { useRef, useCallback, useState, useEffect } from 'react'
 import { AppRegistry, StyleSheet, View, Animated, Platform } from 'react-native'
+import { SecureEncryption } from 'common/native'
 import { withTheme } from 'react-native-paper'
 import { withNavigation, SafeAreaView } from 'react-navigation'
 import { connect } from 'react-redux'
@@ -22,13 +23,26 @@ const Initializer = ({
   wallets
 }) => {
   const move = useRef(new Animated.Value(0))
+  const [ready, setReady] = useState(false)
   const loadingAnim = Animated.loop(
     Animated.sequence([Move.To(move.current, 123), Move.To(move.current, 0)])
   )
   const loadingDuration = 1000 + Math.random() * 1000
 
   useEffect(() => {
-    if (wallets.length === 0) {
+    async function initSecureEncryption() {
+      if (Platform.OS === 'android') {
+        await SecureEncryption.init()
+      }
+      setReady(true)
+    }
+    initSecureEncryption()
+  }, [])
+
+  useEffect(() => {
+    if (!ready) {
+      return
+    } else if (wallets.length === 0) {
       navigation.navigate('Welcome')
     } else if (wallet && provider && blockchainWallet) {
       navigation.navigate('MainContent')
@@ -49,6 +63,7 @@ const Initializer = ({
     loadingDuration,
     navigation,
     provider,
+    ready,
     registerHeadlessService,
     wallet,
     wallets


### PR DESCRIPTION
Closes #132 

This PR utilizes the Android Keystore to safely encrypt the wallet's private key before keep it in the local storage

# Impact
This PR changes the way we store the private key. If the user is coming from the old version, then it needs to uninstall first.