### PR TITLE
Add default case when no assets available

### DIFF
--- a/src/common/constants/onboardingContent.js
+++ b/src/common/constants/onboardingContent.js
@@ -45,7 +45,7 @@ export const ROOTCHAIN_POPUP = {
     enabledOnboarding,
     currentPage,
     nextPopup,
-    rootchainAssets
+    rootchainAssets = []
   }) => {
     return (
       enabledOnboarding &&
@@ -71,7 +71,7 @@ export const ROOTCHAIN_POPUP_EMPTY = {
     enabledOnboarding,
     currentPage,
     nextPopup,
-    rootchainAssets
+    rootchainAssets = []
   }) => {
     return (
       enabledOnboarding &&


### PR DESCRIPTION
To prevent a crash when the onboarding pop-up appears while the assets are still loading.