### PR TITLE
Avoid sending unnecessary errors to sentry

### DIFF
--- a/src/common/actions/actionCreators.js
+++ b/src/common/actions/actionCreators.js
@@ -3,7 +3,8 @@ import { ExceptionReporter } from 'common/reporter'
 export const createAsyncAction = ({
   operation: doAsyncAction,
   type: actionType,
-  isBackgroundTask: isBackgroundTask
+  isBackgroundTask,
+  reportError = true
 }) => {
   return dispatch => {
     const actionStartStatus = isBackgroundTask ? 'LISTENING' : 'INITIATED'
@@ -17,7 +18,9 @@ export const createAsyncAction = ({
       } catch (err) {
         console.log(err)
         dispatch({ type: `${actionType}/FAILED`, err })
-        ExceptionReporter.send(err)
+        if (reportError) {
+          ExceptionReporter.send(err)
+        }
       }
       const actionName = actionType.replace('/', '_')
       dispatch({ type: `LOADING/${actionName}/IDLE` })
@@ -27,7 +30,7 @@ export const createAsyncAction = ({
 
 export const createAction = (
   dispatch,
-  { operation: doAction, type: actionType }
+  { operation: doAction, type: actionType, reportError = true }
 ) => {
   try {
     const result = doAction()
@@ -35,6 +38,8 @@ export const createAction = (
   } catch (err) {
     console.log(err)
     dispatch({ type: `${actionType}/ERROR`, data: err })
-    ExceptionReporter.send(err)
+    if (reportError) {
+      ExceptionReporter.send(err)
+    }
   }
 }

--- a/src/common/actions/walletActions.js
+++ b/src/common/actions/walletActions.js
@@ -29,7 +29,8 @@ export const importByMnemonic = (wallets, mnemonic, provider, name) => {
 
   return createAsyncAction({
     operation: asyncAction,
-    type: 'WALLET/IMPORT'
+    type: 'WALLET/IMPORT',
+    reportError: false
   })
 }
 


### PR DESCRIPTION
Some actions don't need to be reported to sentry when failed e.g. import wallet using seed phrase, the app will be pointing the seed phrase is wrong when getting an error.